### PR TITLE
Maintenance: Refactored review functionality

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16,9 +16,11 @@ env.config()
 const hikeRoute = require('./routes/hike')
 const signup = require('./routes/signup')
 const login = require('./routes/login')
+const review = require('./routes/review')
 app.use('/hike', hikeRoute)
 app.use('/signup', signup)
 app.use('/login', login)
+app.use('/review', review)
 
 const uri = process.env.DB_LINK
 if (!uri) {

--- a/backend/models/reviews-schema.js
+++ b/backend/models/reviews-schema.js
@@ -1,9 +1,11 @@
 const mongoose = require('mongoose')
 
 const types = mongoose.Schema.Types
-const reviewSchema = mongoose.Schema({
+const ReviewSchema = mongoose.Schema({
+  deleted: { type: Boolean, default: false, required: false },
   hike_id: { type: types.ObjectId, required: true },
-  user_id: { type: types.ObjectId, required: false },
+  user_email: { type: String, required: false },
+  user_name: { type: String, required: false },
   body: { type: String, required: true },
   date: { type: Date, default: Date.now, required: false },
   difficulty: { type: Number, required: false },
@@ -11,8 +13,7 @@ const reviewSchema = mongoose.Schema({
   dog_friendly: { type: Boolean, required: false },
   horseback_riding: { type: Boolean, required: false },
   mountain_biking: { type: Boolean, required: false },
-  bird_watching: { type: Boolean, required: false },
-  family_friendly: { type: Boolean, required: false }
+  free_parking: { type: Boolean, required: false }
 })
 
-module.exports = reviewSchema
+module.exports = ReviewSchema

--- a/backend/routes/hike.js
+++ b/backend/routes/hike.js
@@ -6,19 +6,6 @@ const Trail = mongoose.model('Trail', trailSchema, 'hike_data')
 
 // HIKES
 
-router.get('/:id/reviews', (req, res) => {
-  res.send('Get review for each hike page!')
-})
-
-router.get('/:id/reviews', (req, res) => {
-  res.send('Get review for each hike page!')
-})
-
-router.post('/:id/reviews', (req, res) => {
-  console.log(req.body)
-  res.send('Post a review on this hike page')
-})
-
 // testing GET all hikes
 
 router.get('/', async (req, res) => {
@@ -86,58 +73,58 @@ router.post('/', (req, res) => {
 
 // REVIEWS
 
-// GET All the reviews of an individual hike
-router.get('/:id/review', async (req, res) => {
-  try {
-    const hikes = await Trail.find({ _id: req.params.id })
-    res.json(hikes[0].reviews)
-  } catch (err) {
-    res.json({ message: err })
-  }
-})
+// // GET All the reviews of an individual hike
+// router.get('/:id/review', async (req, res) => {
+//   try {
+//     const hikes = await Trail.find({ _id: req.params.id })
+//     res.json(hikes[0].reviews)
+//   } catch (err) {
+//     res.json({ message: err })
+//   }
+// })
 
-// POST method to add a review on the individual hike page by hikeid
-router.post('/:id/review', async (req, res) => {
-  try {
-    const reviewSchema = {
-      user_id: req.body.user_id,
-      reviewBody: req.body.reviewBody,
-      hike_id: req.body.hike_id
-    }
-    await Trail.findByIdAndUpdate(
-      {
-        _id: req.params.id
-      },
-      {
-        $push: {
-          reviews: reviewSchema
-        }
-      }
-    )
-    res.json({ Response: 'Review is added' })
-  } catch (err) {
-    res.json({ message: err })
-  }
-})
+// // POST method to add a review on the individual hike page by hikeid
+// router.post('/:id/review', async (req, res) => {
+//   try {
+//     const reviewSchema = {
+//       user_id: req.body.user_id,
+//       reviewBody: req.body.reviewBody,
+//       hike_id: req.body.hike_id
+//     }
+//     await Trail.findByIdAndUpdate(
+//       {
+//         _id: req.params.id
+//       },
+//       {
+//         $push: {
+//           reviews: reviewSchema
+//         }
+//       }
+//     )
+//     res.json({ Response: 'Review is added' })
+//   } catch (err) {
+//     res.json({ message: err })
+//   }
+// })
 
-// DELETE individual review by id
-router.delete('/:id/review/:reviewID', async (req, res) => {
-  try {
-    await Trail.findOneAndUpdate(
-      {
-        _id: req.params.id
-      },
-      {
-        $pull: {
-          reviews: { _id: req.params.reviewID }
-        }
-      }
-    )
-    res.json({ Response: 'Review is deleted' })
-  } catch (err) {
-    res.json({ message: err })
-  }
-})
+// // DELETE individual review by id
+// router.delete('/:id/review/:reviewID', async (req, res) => {
+//   try {
+//     await Trail.findOneAndUpdate(
+//       {
+//         _id: req.params.id
+//       },
+//       {
+//         $pull: {
+//           reviews: { _id: req.params.reviewID }
+//         }
+//       }
+//     )
+//     res.json({ Response: 'Review is deleted' })
+//   } catch (err) {
+//     res.json({ message: err })
+//   }
+// })
 
 /** *****************POST RATING FOR INDIV HIKE******************** */
 

--- a/backend/routes/review.js
+++ b/backend/routes/review.js
@@ -1,0 +1,93 @@
+const mongoose = require('mongoose')
+const express = require('express')
+const router = express.Router()
+const ReviewSchema = require('../models/reviews-schema')
+const Review = mongoose.model('Review', ReviewSchema, 'review')
+
+// REVIEWS
+// GET All the reviews in reviews db
+router.get('/', async (req, res) => {
+  try {
+    const reviews = await Review.find({ deleted: false })
+    res.json(reviews)
+  } catch (err) {
+    res.json({ message: err })
+  }
+})
+
+// GET All the reviews of an individual hike
+router.get('/:id', async (req, res) => {
+  try {
+    const hikeReviews = await Review.find({ hike_id: req.params.id, deleted: false })
+    res.json(hikeReviews)
+  } catch (err) {
+    res.json({ message: err })
+  }
+})
+
+// POST method to add a review on the individual hike page by hikeid
+router.post('/:id', async (req, res) => {
+  const reviewPost = new Review({
+    deleted: req.body.deleted,
+    hike_id: req.params.id,
+    user_email: req.body.user_email,
+    user_name: req.body.user_name,
+    body: req.body.body,
+    date: req.body.date,
+    difficulty: req.body.difficulty,
+    accessibility: req.body.accessibility,
+    dog_friendly: req.body.dog_friendly,
+    horseback_riding: req.body.horseback_riding,
+    mountain_biking: req.body.mountain_biking,
+    free_parking: req.body.free_parking
+  })
+
+  reviewPost
+    .save()
+    .then((data) => {
+      res.json(data)
+    })
+    .catch((err) => {
+      res.json({ message: err })
+    })
+})
+
+// Soft DELETE individual review by id
+router.post('/:reviewID', async (req, res) => {
+  try {
+    await Review.findOneAndUpdate(
+      {
+        _id: req.params.id
+      },
+      {
+        $push: {
+          deleted: true
+        }
+      }
+    )
+    res.json({ Response: 'Review is marked as deleted' })
+  } catch (err) {
+    res.json({ message: err })
+  }
+})
+
+// Hard DELETE individual review by id
+router.delete('/:reviewID', async (req, res) => {
+  try {
+    await Review.findOneAndUpdate(
+      {
+        _id: req.params.id
+      },
+      {
+        $pull: {
+          reviews: { _id: req.params.reviewID }
+        }
+      }
+    )
+    res.json({ Response: 'Review is deleted' })
+  } catch (err) {
+    res.json({ message: err })
+  }
+})
+
+module.exports = router

--- a/backend/routes/review.js
+++ b/backend/routes/review.js
@@ -53,7 +53,7 @@ router.post('/:id', async (req, res) => {
 })
 
 // Soft DELETE individual review by id
-router.post('/:reviewID', async (req, res) => {
+router.post('/:id/delete', async (req, res) => {
   try {
     await Review.findOneAndUpdate(
       {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3514,6 +3514,15 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6629,6 +6638,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -10361,6 +10376,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -15453,7 +15474,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16052,7 +16077,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/frontend/src/ReviewPage.js
+++ b/frontend/src/ReviewPage.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-script-url */
 import React from "react";
-import PropTypes from 'prop-types'; 
+import PropTypes from 'prop-types';
 import "./css/Review.css";
 import "./css/SinglePage.css";
 import { withRouter } from "react-router-dom";
@@ -23,13 +23,26 @@ class Review extends React.Component {
   submitReview = () => {
     const userName = document.getElementById("email").value;
     const reviewBody = document.getElementById("review-body").value;
+    const accessibility = document.getElementById("accessibility-rating").options[document.getElementById("accessibility-rating").selectedIndex].value;
+    const difficulty = document.getElementById("difficulty-rating").options[document.getElementById("difficulty-rating").selectedIndex].value;
+    const freeParking = document.querySelector("#free-parking").checked
+    const dogFriendly = document.querySelector("#dog-friendly").checked
+    const horseRiding = document.querySelector("#horse-friendly").checked
+    const mountainBiking = document.querySelector("#bike-friendly").checked
+
     const review = {
-      user_id: userName,
-      reviewBody: reviewBody,
+      user_email: userName,
+      body: reviewBody,
       hike_id: this.state._id,
+      difficulty: difficulty,
+      accessibility: accessibility,
+      dog_friendly: dogFriendly,
+      horseback_riding: horseRiding,
+      mountain_biking: mountainBiking,
+      free_parking: freeParking
     };
 
-    fetch("http://localhost:3001/hike/" + this.state._id + "/review", {
+    fetch("http://localhost:3001/review/" + this.state._id, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -38,10 +51,6 @@ class Review extends React.Component {
     }).then(() => {
       this.state.reviews.push(review);
     });
-
-    setTimeout(function () {
-      alert("Hello");
-    }, 50000000);
   };
 
   render() {
@@ -99,21 +108,21 @@ class Review extends React.Component {
             <p id="input" style={{ marginLeft: "45px" }}>
               Activities permitted:
             </p>
-            <label>
+            <label >
               <span style={{ marginLeft: "45px" }}>dog-friendly</span>
-              <input type="checkbox" value="1" />
+              <input id="dog-friendly" type="checkbox" value="1" />
             </label>
-            <label>
+            <label >
               <span>horse-friendly</span>
-              <input type="checkbox" value="1" />
+              <input id="horse-friendly" type="checkbox" value="1" />
             </label>
-            <label>
+            <label >
               <span>bike-friendly</span>
-              <input type="checkbox" value="1" />
+              <input id="bike-friendly" type="checkbox" value="1" />
             </label>
-            <label>
+            <label >
               <span>free-parking</span>
-              <input type="checkbox" value="1" />
+              <input id="free-parking" type="checkbox" />
             </label>
           </div>
 

--- a/frontend/src/SinglePage.js
+++ b/frontend/src/SinglePage.js
@@ -98,7 +98,7 @@ class SinglePage extends React.Component {
             Reviews
             <hr />
           </h2>
-          <ReviewTable reviewList={this.state.reviews} />
+          <ReviewTable reviewList={this.state._id} />
         </div>
       </div>
     );

--- a/frontend/src/components/ReviewTable.js
+++ b/frontend/src/components/ReviewTable.js
@@ -1,57 +1,94 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 function ReviewBody(props) {
   const rows = props.reviewList.map((row, index) => {
     return (
       <tr key={index}>
-        <td style={{ width: "150px" }}>
-          Review by: <br></br>
-          {row.user_id}
+        <td style={{ width: "200px" }}>
+          Review by: {row.user_email} <br></br>
+           on {row.date.substring(0, 10)}
         </td>
-        <td style={{ width: "150px" }}>
-          Date: <br></br>
-          {row.date}
+        <td style={{ width: "200px" }}>
+          Accessibility: {row.accessibility}
+          <br></br>
+          Difficulty: {row.difficulty}
         </td>
-        <td>{row.reviewBody}</td>
+
+        <td style={{ width: "400px" }}>
+          Activities permitted: {getActivities(row)}
+        </td>
+        <td>
+          Comment: <br></br>
+          {row.body}
+        </td>
       </tr>
     );
   });
-
   return <tbody>{rows}</tbody>;
 }
 
-function EmptyReviews(props) {
+function getActivities(row) {
+  console.log(row);
+  var list = [];
+  if (row.dog_friendly === true)
+    list.push("dog friendly")
+  if (row.free_parking === true)
+    list.push("free parking")
+  if (row.horseback_riding === true)
+    list.push("horse riding")
+  if (row.mountain_biking === true)
+    list.push("biking")
+  if (list.length !== 0)
+    return list.join(", ");
+  else
+    return "n/a";
+}
+
+function EmptyReviews() {
   return <h3>No reviews yet.</h3>;
 }
 
 function ReviewTable(props) {
+  // TODO: Fix this manual review CSS
   const divStyle = {
-    margin: " 5px 100px 5px",
-    width: "1300px",
+    // Top , right , bottom , left
+    margin: "2% 5% 0% 5%",
+    width: "90%"
+
   };
 
-  const hasReview = props.reviewList;
   let reviewTable;
-  let noReviews;
+  let noReviews = null;
 
-  if (hasReview) {
-    reviewTable = <ReviewBody reviewList={props.reviewList} />;
-
-    // Display message if there are currently no reviews
-    if (Object.keys(props.reviewList).length === 0) {
-      noReviews = <EmptyReviews />;
-    }
-  } else {
-    reviewTable = null;
+  if (typeof props.reviewList === "undefined") {
+    return null;
   }
+  else if (props) {
+    const [state, setState] = useState([]);
+    useEffect(() => {
+      // TODO: Update the local api to live site when we fix everything
+      fetch("http://localhost:3001/review/" + props.reviewList)
+        .then((resp) => resp.json())
+        .then(data => setState(data))
+    }, []);
 
-  return (
-    <div className="table">
-      <table style={divStyle}>{reviewTable}</table>
-      {noReviews}
-    </div>
-  );
+
+    if (state) {
+      reviewTable = <ReviewBody reviewList={state} />;
+      // Display message if there are currently no reviews
+      if (Object.keys(state).length === 0) {
+        noReviews = <EmptyReviews />;
+      }
+    }
+
+    return (
+      <div className="table">
+        <table style={divStyle}>{reviewTable}</table>
+        {noReviews}
+      </div>
+    );
+  }
 }
 
 export default ReviewTable;


### PR DESCRIPTION
## Description

In this refactor, number of things related to reviews were fixed:
1. Changed the review schema. Now all of the reviews are stored in different collection in our database.
2. Added separate backend route for the reviews and the necessary endpoints for reviews to work. 
   -  Example (on localhost): 
      - to get all reviews in db: `http://127.0.0.1:3001/review` 
      - for a single hike: `http://127.0.0.1:3001/review/<hike_id>` 
      - for a particular user (name field on review form): `http://127.0.0.1:3001/review/<user>` 
3. Now all of the fields can be submitted and stored in the database through the review form page. 
4. All of the review information are displayed on the Single hike page.
![Screen Shot 2021-05-08 at 11 04 39 PM](https://user-images.githubusercontent.com/23184246/117562196-ec67d780-b051-11eb-9d17-a1c9e7af3b38.png)
 

closes #55, #76, #77, and #85